### PR TITLE
fix: arruma a disposição de itens na dashboard

### DIFF
--- a/src/frontend/pharmabot/src/app/components/StopButton.tsx
+++ b/src/frontend/pharmabot/src/app/components/StopButton.tsx
@@ -8,15 +8,15 @@ export default function StopButton({ status, onClick }: StopButtonProps) {
         
     <button
         onClick={onClick}
-        className={`w-19 h-19 font-bold rounded-full text-center cursor-pointer ${
+        className={`w-19 h-19 font-bold rounded-full text-center cursor-pointer text-white ${
             status === "Pausado"
-                ? "bg-yellow-500 text-black"
+                ? "bg-green-600"
                 : status === "Desconectado"
-                ? "bg-gray-500 text-white"
-                : "bg-red-500 text-white"
+                ? "bg-gray-500"
+                : "bg-red-500"
         }`}
     >
-        PARAR
+        {status === "Pausado" ? "INICIAR" : status === "Desconectado" ? "-" : "PARAR"}
     </button>
 
     );

--- a/src/frontend/pharmabot/src/app/kanban/components/Column.tsx
+++ b/src/frontend/pharmabot/src/app/kanban/components/Column.tsx
@@ -30,10 +30,10 @@ const Column: React.FC<ColumnProps> = ({
     updateTask: updateFita,
 }) => {
     return (
-        <div className="flex-1 h-full flex flex-col">
-            <div className="flex text-xl md:text-3xl p-2 font-bold text-white justify-center">
+        <div className={`flex-1 rounded ${status == "em-preparo" || status == "separado" ? 'bg-gray-200 opacity-75 cursor-not-allowed' : '' } h-full flex flex-col`}>
+            <div className={`flex text-xl md:text-xl tracking-wider p-2 font-bold text-white justify-center`}>
                 <h2 className="capitalize bg-[#3F3047] p-3 rounded-xl">
-                    {status}
+                    {status == "em-preparo" ? "Em Preparo" : status }
                 </h2>
             </div>
             <div


### PR DESCRIPTION
# Pull Request - Arruma a disposição de itens na dashboard

Este pull request atualiza **a disposição de itens na dashboard**.

## Descrição

- **O que está sendo feito?**  
  block em "Em Preparo" e "Separado". Tirado o hifen do Em Preparo. Menos opacidade em preparo e separado.  Uso de - para desconectado, iniciar para pausado e parar para funcionando. Verde quando pausado.

- **Por que está sendo feito?**  
  Testes de usabilidade

## Checklist

Por favor, revisar os pontos mencionados abaixo antes de aprovar:

- [ ] **Testes e Validações (opcional):** Caso haja testes automatizados ou manuais, verifique se eles foram atualizados ou criados para refletir as mudanças.

## Observações

Estou à disposição para qualquer alteração ou melhoria!

## Revisores

@iisabelledantas 
